### PR TITLE
fix (CD): Continous Delivery

### DIFF
--- a/ansible/deploy_app.yml
+++ b/ansible/deploy_app.yml
@@ -1,0 +1,43 @@
+---
+- name: Update Microblog Application
+  hosts: appserver
+  serial: 1
+  vars:
+    dockerhub_username: "{{ secrets.DOCKERHUB_USERNAME }}"
+    ansible_python_interpreter: /usr/bin/python3
+  remote_user: deploy
+  become: yes
+  become_method: sudo
+  roles:
+    - docker-install
+  tasks:
+    - name: Pull the latest Microblog image based on GitHub release tag
+      docker_image:
+        name: "{{ dockerhub_username }}/microblog:{{ github_tag }}-prod"
+        source: pull
+
+    - name: Restart Microblog Container
+      docker_container:
+        name: microblog
+        image: "{{ dockerhub_username }}/microblog:{{ github_tag }}-prod"
+        env:
+          SECRET_KEY: "my_precious"
+          DATABASE_URL: "mysql+pymysql://microblog:microblog@{{ groups['database'][0] }}:3306/microblog"
+        ports:
+          - "8000:5000"
+        restart_policy: always
+        published_ports:
+          - "8000:5000"
+        state: started
+
+    - name: Wait for the application to start
+      wait_for:
+        port: 8000
+        delay: 10
+
+    - name: Verify the deployment
+      uri:
+        url: "http://{{ inventory_hostname }}:8000/"
+        return_content: yes
+        status_code: 200
+      register: result


### PR DESCRIPTION
Gjort det så att nya uppdateringar vid push på branches faktiskt går ut och uppdaterar servrarna som är i fokus. Där har lagts till ett nytt jobb som heter deploy.yml som då loggar in mot azure och uppdaterar samtliga appservrar som hittas under ansible/hosts.